### PR TITLE
fix: svgo peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "prettier": "latest",
     "turbo": "latest"
   },
+  "pnpm": {
+    "overrides": {
+      "svgo": "3.0.2"
+    }
+  },
   "packageManager": "pnpm@7.18.2",
   "keywords": [],
   "license": "MIT"


### PR DESCRIPTION
This will temporarily patch the peer deps issue after `pnpm i`. Until Parcel upgrade their peer deps, this suffice for now. The alternative is to fork parcel's dependency and replace it in plasmo, tho that'd take more time...