### PR TITLE
fix: adapt transformRequest for new MediaResponse type

### DIFF
--- a/apps/extension/src/background/ports/media.ts
+++ b/apps/extension/src/background/ports/media.ts
@@ -10,11 +10,10 @@ import {
   type PortResponse,
 } from "~core/constants"
 import { PortName } from "~core/constants"
-import { type Config, configManager, AuthType } from "~core/managers/config"
+import { configManager, AuthType } from "~core/managers/config"
 import {
   transactionManager
 } from "~core/managers/transaction"
-import { Extension } from "~core/extension"
 import {
   err,
   isErr,

--- a/apps/extension/src/core/media/openrouter.ts
+++ b/apps/extension/src/core/media/openrouter.ts
@@ -33,11 +33,22 @@ export function init(
       },
       transformResponse: (res) => {
         const anyRes = res as any
-        return anyRes["data"].map(
-          ({ uri, url }: { uri: string; url: string | null }) => {
-            return { uri, url }
-          }
-        )
+        let result = anyRes["data"]
+        if("objects" in result){
+          result = result["objects"].map(
+            ({ uri, url }: { uri: string; url: string | null }) => {
+              return { uri, url }
+            }
+          )
+        }
+        else if(Array.isArray(result)){
+          result = result.map(
+            ({ uri, url }: { uri: string; url: string | null }) => {
+              return { uri, url }
+            }
+          )
+        }
+        throw new Error("Unexpected response from OpenRouter media model.")
       }
     },
     opts

--- a/apps/extension/src/core/media/openrouter.ts
+++ b/apps/extension/src/core/media/openrouter.ts
@@ -35,13 +35,13 @@ export function init(
         const anyRes = res as any
         // TODO: remove this once openrouter endpoint is migrated from returning a "data" param
         const result = "data" in anyRes ? anyRes.data : anyRes
-        let objects: any = []
-        if ("objects" in result) {
-          objects = result.objects
+        let generations: any = []
+        if ("generations" in result) {
+          generations = result.generations
         } else if (Array.isArray(result)) {
-          objects = result
+          generations = result
         }
-        return objects.map(
+        return generations.map(
           ({ uri, url }: { uri: string; url: string | null }) => {
             return { uri, url }
           }

--- a/apps/extension/src/core/media/openrouter.ts
+++ b/apps/extension/src/core/media/openrouter.ts
@@ -34,13 +34,8 @@ export function init(
       transformResponse: (res) => {
         const anyRes = res as any
         // TODO: remove this once openrouter endpoint is migrated from returning a "data" param
-        const result = "data" in anyRes ? anyRes.data : anyRes
-        let generations: any = []
-        if ("generations" in result) {
-          generations = result.generations
-        } else if (Array.isArray(result)) {
-          generations = result
-        }
+        const results = "data" in anyRes ? anyRes.data : anyRes
+        const generations = Array.isArray(results) ? results : results.generations
         return generations.map(
           ({ uri, url }: { uri: string; url: string | null }) => {
             return { uri, url }

--- a/apps/extension/src/core/media/openrouter.ts
+++ b/apps/extension/src/core/media/openrouter.ts
@@ -35,7 +35,7 @@ export function init(
         const anyRes = res as any
         // TODO: remove this once openrouter endpoint is migrated from returning a "data" param
         const result = "data" in anyRes ? anyRes.data : anyRes
-        let objects = []
+        let objects: any = []
         if ("objects" in result) {
           objects = result.objects
         } else if (Array.isArray(result)) {

--- a/apps/extension/src/core/media/openrouter.ts
+++ b/apps/extension/src/core/media/openrouter.ts
@@ -33,22 +33,19 @@ export function init(
       },
       transformResponse: (res) => {
         const anyRes = res as any
-        let result = anyRes["data"]
-        if("objects" in result){
-          result = result["objects"].map(
-            ({ uri, url }: { uri: string; url: string | null }) => {
-              return { uri, url }
-            }
-          )
+        // TODO: remove this once openrouter endpoint is migrated from returning a "data" param
+        const result = "data" in anyRes ? anyRes.data : anyRes
+        let objects = []
+        if ("objects" in result) {
+          objects = result.objects
+        } else if (Array.isArray(result)) {
+          objects = result
         }
-        else if(Array.isArray(result)){
-          result = result.map(
-            ({ uri, url }: { uri: string; url: string | null }) => {
-              return { uri, url }
-            }
-          )
-        }
-        throw new Error("Unexpected response from OpenRouter media model.")
+        return objects.map(
+          ({ uri, url }: { uri: string; url: string | null }) => {
+            return { uri, url }
+          }
+        )
       }
     },
     opts


### PR DESCRIPTION
- Prepares window.ai clients from a migration from `MediaResponses` consisting of an array data type to an object oriented data type. 
- Side note: removed some unused imports in the `ports/media.ts` file


Resolves WIN-62