### PR TITLE
feat: improve API key configuration screen

### DIFF
--- a/apps/extension/src/contents/inpage.ts
+++ b/apps/extension/src/contents/inpage.ts
@@ -25,6 +25,7 @@ import { isOk } from "~core/utils/result-monad"
 
 import { version } from "../../package.json"
 
+
 export const config: PlasmoCSConfig = {
   matches: ["<all_urls>"],
   world: "MAIN",

--- a/apps/extension/src/core/components/pure/Input.tsx
+++ b/apps/extension/src/core/components/pure/Input.tsx
@@ -8,6 +8,7 @@ export function Input({
   name,
   onChange,
   onBlur,
+  onEnter,
   placeholder,
   children,
   required,
@@ -18,6 +19,7 @@ export function Input({
   type?: "text" | "password" | "email" | "number" | "url"
   onChange: (newValue: string) => void
   onBlur?: (newValue: string) => void
+  onEnter?: () => void
   placeholder?: string
   children?: React.ReactNode
   required?: boolean
@@ -32,6 +34,11 @@ export function Input({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onBlur={(e) => onBlur && onBlur(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && onEnter) {
+              onEnter()
+            }
+          }}
           placeholder={placeholder}
           required={required}
           className="mt-2 w-full px-4 py-2 border dark:bg-slate-200 rounded-md shadow-sm text-slate-900 focus:border-indigo-300 focus:ring focus:ring-indigo-200 required:border-red-500 focus:ring-opacity-50"

--- a/apps/extension/src/core/utils/utils.ts
+++ b/apps/extension/src/core/utils/utils.ts
@@ -2,7 +2,7 @@ import { type ChatMessage, isMediaExtension } from "window.ai"
 
 export function log(...args: unknown[]) {
   if (process.env.NODE_ENV === "development") {
-    console.log(...args)
+    console.log(`[window.ai]`, ...args)
   }
 }
 

--- a/apps/extension/src/core/views/Settings.tsx
+++ b/apps/extension/src/core/views/Settings.tsx
@@ -30,7 +30,7 @@ const configSettings: ConfigSetting[] = [
   { auth: AuthType.APIKey } // Local model
 ]
 
-export function Settings() {
+export function Settings(props: { onHide: () => void }) {
   const { config, setConfig } = useConfig()
   const { data } = usePermissionPort()
   const { requestId } = useParams()
@@ -64,6 +64,11 @@ export function Settings() {
       apiKey: apiKey || undefined,
       baseUrl: url || undefined
     })
+  }
+
+  async function handleSaveAction() {
+    await saveAll()
+    props.onHide()
   }
 
   const isLocalModel = config && configManager.isLocal(config)
@@ -132,12 +137,22 @@ export function Settings() {
 
           <div>
             {asksForAPIKey && (
-              <Input
-                placeholder="API Key"
-                value={apiKey || ""}
-                onChange={(val) => setApiKey(val)}
-                onBlur={saveAll}
-              />
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder="API Key"
+                  value={apiKey || ""}
+                  onChange={(val) => setApiKey(val)}
+                  onBlur={saveAll}
+                  onEnter={handleSaveAction}
+                />
+                {Boolean(apiKey) && (
+                  <div className="relative top-1">
+                    <Button onClick={handleSaveAction}>
+                      Save
+                    </Button>
+                  </div>
+                )}
+              </div>
             )}
             {isExternal && <ExternalSettings config={config} />}
             <div className="mt-3"></div>

--- a/apps/extension/src/popup.tsx
+++ b/apps/extension/src/popup.tsx
@@ -49,6 +49,10 @@ function NavFrame() {
     }
   }, [requestId])
 
+  function hideSettings() {
+    setSettingsShown(false)
+  }
+
   return (
     <div className="h-full">
       {requestId ? (
@@ -67,8 +71,8 @@ function NavFrame() {
       <SlidingPane
         shown={settingsShown}
         animated={settingsShown}
-        onHide={() => setSettingsShown(false)}>
-        <Settings />
+        onHide={hideSettings}>
+        <Settings onHide={hideSettings}/>
       </SlidingPane>
     </div>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 overrides:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 overrides:


### PR DESCRIPTION
## what
Added a button to save the API Key when the users interacts with in a environment that hasn't been configured, or when the keys provided are invalid. Pressing Enter on the input also works!

<img width="497" alt="image" src="https://github.com/alexanderatallah/window.ai/assets/8951736/2c96c9c2-68fc-415b-9672-7890190c9435">

## why
It's kinda confusing to have to blur the input and/or click the X on top right to proceed to the completion! 
